### PR TITLE
Add ordinal function to Enum.

### DIFF
--- a/Enum.js
+++ b/Enum.js
@@ -97,7 +97,7 @@ Enum.create = function(config) {
     Type.names = [];
     Type.values = [];
 
-    function createEnumValue(name, value) {
+    function createEnumValue(name, value, ordinal) {
         Type.names.push(name);
 
         var enumValue = new Type(value);
@@ -109,6 +109,10 @@ Enum.create = function(config) {
 
         Type[name] = Type[Enum.toConstantName(name)] = enumValue;
 
+        Type[name].ordinal = function() {
+            return ordinal;
+        };
+
         Type.values.push(enumValue);
 
         return enumValue;
@@ -116,16 +120,13 @@ Enum.create = function(config) {
 
     if (Array.isArray(values)) {
         values.forEach(function(value, index) {
-            createEnumValue(value, value);
+            createEnumValue(value, value, index);
         });
     } else {
-        for (var name in values) {
-            if (values.hasOwnProperty(name)) {
-                createEnumValue(name, values[name]);
-            }
-        }
+        Object.keys(values).forEach(function(name, index) {
+            createEnumValue(name, values[name], index);
+        });
     }
-
 
     Type.preventConstruction();
 

--- a/README.md
+++ b/README.md
@@ -606,6 +606,9 @@ assert(Color.RED.value() === 'red');
 
 // Clean the enum value which will return its name
 assert(Color.RED.clean() === 'red');
+
+// Get the ordinal value associated with index of the value.
+assert(Color.RED.ordinal() === 0);
 ```
 
 **Object enum values:**
@@ -636,6 +639,7 @@ assert(Color.red.value().name === 'Red');
 assert(Color.RED.name() === 'red');
 assert(Color.RED.value().hex === '#FF0000');
 assert(Color.RED.value().name === 'Red');
+assert(Color.RED.ordinal() === 0);
 ```
 
 **Loop over values:**

--- a/test/enum-test.js
+++ b/test/enum-test.js
@@ -36,6 +36,9 @@ describe('Enum', function() {
         expect(Gender.F.isM()).to.equal(false);
         expect(Gender.F.isF()).to.equal(true);
 
+        expect(Gender.M.ordinal()).to.equal(0);
+        expect(Gender.F.ordinal()).to.equal(1);
+
         var person1 = new Person({
             gender: 'F'
         });
@@ -49,6 +52,8 @@ describe('Enum', function() {
 
         expect(person2.getGender().isM()).to.equal(true);
         expect(person2.getGender().isF()).to.equal(false);
+
+        expect(person2.getGender().ordinal()).to.equal(0);
     });
 
     it('should allow enum object values', function() {
@@ -93,6 +98,9 @@ describe('Enum', function() {
 
         expect(Color.blue.value().hex).to.equal('#0000FF');
         expect(Color.blue.value().name).to.equal('Blue');
+
+        expect(Color.red.ordinal()).to.equal(0);
+        expect(Color.green.ordinal()).to.equal(1);
     });
 
     it('should allow unwrapping an enum', function() {


### PR DESCRIPTION
Support for the following:

```javascript
var Gender = Enum.create({
    values: ['M', 'F'],
    autoUpperCase: true
});

assert(Gender.M.ordinal() === 0);
assert(Gender.F.ordinal() === 1);
```

Also works for objects:

```javascript
var Color = Enum.create({
    values: {
        red: {
            hex: '#FF0000',
            name: 'Red'
        },

        green: {
            hex: '#00FF00',
            name: 'Green'
        },

        blue: {
            hex: '#0000FF',
            name: 'Blue'
        }
    }
});

assert(Color.RED.ordinal() === 0);
assert(Color.GREEN.ordinal() === 1);
assert(Color.BLUE.ordinal() === 2);
```